### PR TITLE
Fix incorrect display of size for network drives

### DIFF
--- a/udisks-indicator
+++ b/udisks-indicator
@@ -585,7 +585,7 @@ class UdisksIndicator(object):
     def get_network_entries(self):
         result = []
         lines = []
-        proc = subprocess.Popen('df', stdout=subprocess.PIPE)
+        proc = subprocess.Popen(["df", "--block-size=1"], stdout=subprocess.PIPE)
 
         for line in proc.stdout.readlines():
             lines.append(line.strip().split())


### PR DESCRIPTION
Incorrect size was displayed because df displays size in 1K-blocks per default. udisks-indicator, however, expects sizes in bytes. My 2 TB HDD consists of 2 partitions of 1TB and 797GB, which now correctly show up. Screenshots [before](https://i.snag.gy/GmHiaU.jpg) and [after](https://i.snag.gy/oiZV6P.jpg).